### PR TITLE
Fix link to svg2pdc tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ point is closest to. It then returns where on the path the point should be
 
 ## Tools
 
-The [SVG2PDC](./tools/svg2pdc.py) script converts SVG images to a PDC (Pebble Draw Command) 
-binary format image or sequence.
+The 
+[SVG2PDC](https://github.com/pebble-examples/cards-example/blob/master/tools/svg2pdc.py) 
+script converts SVG images to a PDC (Pebble Draw Command) binary format image or 
+sequence.
 
 #### Usage
 


### PR DESCRIPTION
@gusatb I remember telling you to link to the main copy of the tool in `cards-example`, which it will do after closing this. 

Ping @sarfata 
